### PR TITLE
Start adb server on the very beginning

### DIFF
--- a/qml/Home.qml
+++ b/qml/Home.qml
@@ -6,7 +6,13 @@ import Ubuntu.Components 0.1
 Item {
     Component.onCompleted: {
         console.log('Home loaded')
-        sic.start(applicationDirPath + '/utils/adb', ['shell', 'system-image-cli', '-i'])
+        cmd_adb.start(applicationDirPath + '/utils/adb', ['start-server'])
+    }
+    Process {
+        id: cmd_adb
+        onReadyRead:{
+            sic.start(applicationDirPath + '/utils/adb', ['shell', 'system-image-cli', '-i'])
+        }
     }
     Process {
         id: sic


### PR DESCRIPTION
Start adb server in the very beginning, so that the daemon
log won't be printed on the screen.
