### PR TITLE
Load pages when adb is ready in the main frame

### DIFF
--- a/qml/Home.qml
+++ b/qml/Home.qml
@@ -6,13 +6,7 @@ import Ubuntu.Components 0.1
 Item {
     Component.onCompleted: {
         console.log('Home loaded')
-        cmd_adb.start(applicationDirPath + '/utils/adb', ['start-server'])
-    }
-    Process {
-        id: cmd_adb
-        onReadyRead:{
-            sic.start(applicationDirPath + '/utils/adb', ['shell', 'system-image-cli', '-i'])
-        }
+        sic.start(applicationDirPath + '/utils/adb', ['shell', 'system-image-cli', '-i'])
     }
     Process {
         id: sic

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -20,12 +20,13 @@ Window {
                 connectIndicator.color = Colour.palette['Green']
                 connectText.text = "Connected"
             }
+            loader.source = "Home.qml";
         }
     }
 
     Component.onCompleted: {
         process.start(applicationDirPath + "/utils/adb", ["devices"]); 
-        loader.source = "Home.qml";
+//        loader.source = "Home.qml";
     }
 
     Rectangle {


### PR DESCRIPTION
Use the main frame as the adb server starter.
Load Home QML when adb is ready.
