### PR TITLE
Add AppArmor syslog watcher feature

### DIFF
--- a/qml/LogWatcher.qml
+++ b/qml/LogWatcher.qml
@@ -1,0 +1,118 @@
+import QtQuick 2.0
+import Process 1.0
+import "colour.js" as Colour
+import QtQuick.Dialogs 1.2
+import Ubuntu.Components 1.3
+import QtQuick.Layouts 1.2
+
+
+Item {
+    Component.onCompleted: {
+        console.log('SysLog Watcher loaded')
+          cmd_sysLog.start(applicationDirPath + '/utils/syslog_watcher.py', ['--app', appNameLabel.text])
+    }
+    Process {
+        id: cmd_sysLog
+        onReadyRead: {
+            var string = readAll()
+            sysLog.text += string
+            console.log(sysLog.text)
+        }
+    }
+
+    Column {
+        id: mainCol
+        anchors { 
+            fill: parent
+            margins: 30
+            
+            horizontalCenter: parent.horizontalCenter
+        }
+        spacing: units.gu(2)
+        Row {
+            id: titleRow
+            spacing: units.gu(2)
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+            }
+            Text {
+                id: title
+                text: i18n.tr("AppArmor Syslog Watcher")
+                font.pointSize: 16
+            }
+        }
+        Row {
+            id: filterRow
+            spacing: units.gu(1)
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+            }
+            Text {
+                id: filterLabel
+                text: i18n.tr("Watch 'DENIED' events only:")
+            }
+            Switch {
+                id: filterSwitch
+                checked: false
+                onClicked: toggle()
+
+                function toggle(){
+                    if (clearCB.checked){
+                        sysLog.text = ""
+                    }
+                    if (filterSwitch.checked){
+                        cmd_filterGo.start(applicationDirPath + '/utils/syslog_watcher.py', ['--denied'])
+                    } else {
+                        cmd_sysLog.start(applicationDirPath + '/utils/syslog_watcher.py', ['--app', appNameLabel.text])
+                    }
+                }
+            }
+            CheckBox {
+                id: clearCB
+            }
+            Label {
+                text: i18n.tr("Clear current content")
+                anchors.verticalCenter: parent.verticalCenter
+                MouseArea{
+                    anchors.fill: parent
+                    onClicked: {
+                        clearCB.checked = !clearCB.checked
+                    }
+                }
+            }
+            Process {
+            id: cmd_filterGo
+                onReadyRead: {
+                    var string = readAll()
+                    sysLog.text += string
+                }
+            }
+        }
+        Row {
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+             }
+            Text {
+                text: i18n.tr('Apparmor Syslog Monitor')
+                font.pointSize: 16
+            }
+        }
+        Row {
+            Flickable {
+                contentHeight: sysLog.contentHeight
+                width: mainCol.width
+                height: 500
+                clip: true
+
+                TextEdit {
+                    id: sysLog
+                    anchors.fill: parent
+                    font.pointSize: 10
+                    selectionColor: Colour.palette['Green']
+                    wrapMode: TextEdit.WordWrap
+                    cursorPosition: sysLog.text.length
+                }
+            }
+        }
+    }
+}

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -112,6 +112,7 @@ Window {
             ListElement { name: "CheckConfig" }
             ListElement { name: "FileWatcher" }
             ListElement { name: "NetWatcher" }
+            ListElement { name: "LogWatcher" }
         }
 
         delegate: Component {

--- a/utils/syslog_watcher.py
+++ b/utils/syslog_watcher.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+'''
+Script for monitoring syslog.
+
+Author: Po-Hsu Lin <po-hsu.lin@canonical.com>
+'''
+
+import argparse
+import datetime
+import re
+import subprocess
+import sys
+
+parser = argparse.ArgumentParser(description='Syslog monitor')
+group = parser.add_mutually_exclusive_group(required=True)
+group.add_argument('--denied', action='store_true',
+                   help='Monitor DENIED pattern in syslog')
+group.add_argument('--app', help='Targeted app')
+args = parser.parse_args()
+
+try:
+    if args.denied:
+        proc_name = 'DENIED'
+    else:
+        proc_name = args.app
+    proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
+    if proc_id.isnumeric() or args.denied:
+        # Try to kill tailf process first
+        output = subprocess.check_output(['adb', 'shell', 'sudo', 'pkill', '-f', 'tailf'])
+        process = subprocess.Popen(['adb', 'shell', 'tailf', '/var/log/syslog', '|', 'grep', proc_name], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        while True:
+            output = process.stdout.readline().decode('utf-8').strip()
+            if output == '' and process.poll() is not None:
+                break
+            else:
+                # Reformat the output, remove everything till apparmor: 
+                # Jul  4 07:44:41 ubuntu-phablet kernel: [49335.660041]  [2:     QQmlThread: 6411] [c2] type=1400 audit(1467618281.378:140077): apparmor="DENIED" operation="open" profile="webbrowser-app" name="/run/shm/lttng-ust-wait-6" pid=6411 comm="QQmlThread" requested_mask="r" denied_mask="r" fsuid=32011 ouid=32011
+                output = re.sub('.*apparmor=', 'apparmor:', output)
+                output = re.sub('operation=', 'action:', output)
+                # remove fsuid/ouid
+                output = re.sub('fsuid=\d+\souid=\d+', '', output)
+                # remove pid
+                output = re.sub('pid=\d+\s', '', output)
+
+                # output here
+                timestamp='{:%Y%m%d %H:%M:%S}'.format(datetime.datetime.now())
+                print(timestamp, '-', output)
+                sys.stdout.flush()
+    else:
+        print(proc_name, "is not running")
+
+except KeyboardInterrupt:
+    print("Process Terminated by user")


### PR DESCRIPTION
Add the syslog watcher tool, specific to AppArmor messages.
With filter feature, tester can watch only DENIED messages.

This closes #35 
