### PR TITLE
Print app name in zh_CN translated string

### DIFF
--- a/qml/AppLauncher.qml
+++ b/qml/AppLauncher.qml
@@ -26,11 +26,12 @@ Item {
         onReadyRead: {
             var items = readAll().toString().replace(/\n$/, "").split('\n')
             for (var i in items) {
-                var item = items[i].split(',')[0].trim()
-                var exec = items[i].split(',')[1].trim()
-                var info = items[i].split(',')[2].trim()
-                console.log(item, '-', exec)
-                app_list.append( {text: item, app: exec, maintainer: info} )
+                var name = items[i].split(',')[0].trim()
+                var vers = items[i].split(',')[1].trim()
+                var exec = items[i].split(',')[2].trim()
+                var info = items[i].split(',')[3].trim()
+                console.log(name, vers, '-', exec)
+                app_list.append( {'text': name + vers, 'name': name, 'proc': exec, 'maintainer': info} )
             }
             hintText.text = "Ready"
             hintText.color = "lime"
@@ -125,12 +126,12 @@ Item {
                 model: ListModel{
                     id: app_list
                     Component.onCompleted: {
-                        append({'text': i18n.tr("Select App..."), 'app': '', 'maintainer': i18n.tr("Please select an App...")})
+                        append({'text': i18n.tr("Select App..."), 'name': '', 'proc': '', 'maintainer': i18n.tr("Select App...")})
                     }
                 }
                 onCurrentIndexChanged: {
                     authorText.text = app_list.get(currentIndex).maintainer
-                    console.debug(app_list.get(currentIndex).text + ", " + app_list.get(currentIndex).app)
+                    console.debug(app_list.get(currentIndex).text + ", " + app_list.get(currentIndex).proc)
                 }
             }
 
@@ -145,10 +146,11 @@ Item {
                 onClicked: {
                     if (app_cb.currentIndex != 0){
                         console.log("Lauching App: " + app_list.get(app_cb.currentIndex).text)
-                        launch_cmd.start(applicationDirPath + '/utils/launch_app.sh', [app_list.get(app_cb.currentIndex).app])
+                        launch_cmd.start(applicationDirPath + '/utils/launch_app.sh', [app_list.get(app_cb.currentIndex).proc])
                         hintText.text = i18n.tr("App monitoring started")
                         hintText.color = ""
-                        appNameLabel.text = app_list.get(app_cb.currentIndex).app
+                        appNameLabel.text = app_list.get(app_cb.currentIndex).name
+                        appProcLabel.text = app_list.get(app_cb.currentIndex).proc
                     } else {
                         console.log("Please select an app to start")
                         hintText.text = i18n.tr("Please select an app to start")

--- a/qml/CheckConfig.qml
+++ b/qml/CheckConfig.qml
@@ -18,9 +18,9 @@ import Ubuntu.Components 1.3
 Item {
     Component.onCompleted: {
         console.log('Check Config')
-        cmd_mode.start(applicationDirPath + '/utils/check_config.py', ['--check-mode', '--app', appNameLabel.text])
-        cmd_proc.start(applicationDirPath + '/utils/check_config.py', ['--check-process', '--app', appNameLabel.text])
-        cmd_policy.start(applicationDirPath + '/utils/check_config.py', ['--check-policy', '--app', appNameLabel.text])
+        cmd_mode.start(applicationDirPath + '/utils/check_config.py', ['--check-mode', '--proc', appNameLabel.text])
+        cmd_proc.start(applicationDirPath + '/utils/check_config.py', ['--check-process', '--proc', appNameLabel.text])
+        cmd_policy.start(applicationDirPath + '/utils/check_config.py', ['--check-policy', '--proc', appNameLabel.text])
     }
     Process {
         id: cmd_mode
@@ -167,7 +167,7 @@ Item {
                 left: rulesLabel.right
             }
             onClicked: {
-                cmd_rules.start(applicationDirPath + '/utils/check_config.py', ['--copy-rules', '--app', appNameLabel.text])
+                cmd_rules.start(applicationDirPath + '/utils/check_config.py', ['--copy-rules', '--proc', appNameLabel.text])
             }
         }
         Process {

--- a/qml/CheckConfig.qml
+++ b/qml/CheckConfig.qml
@@ -18,9 +18,9 @@ import Ubuntu.Components 1.3
 Item {
     Component.onCompleted: {
         console.log('Check Config')
-        cmd_mode.start(applicationDirPath + '/utils/check_config.py', ['--check-mode', '--proc', appNameLabel.text])
-        cmd_proc.start(applicationDirPath + '/utils/check_config.py', ['--check-process', '--proc', appNameLabel.text])
-        cmd_policy.start(applicationDirPath + '/utils/check_config.py', ['--check-policy', '--proc', appNameLabel.text])
+        cmd_mode.start(applicationDirPath + '/utils/check_config.py', ['--check-mode', '--proc', appProcLabel.text])
+        cmd_proc.start(applicationDirPath + '/utils/check_config.py', ['--check-process', '--proc', appProcLabel.text])
+        cmd_policy.start(applicationDirPath + '/utils/check_config.py', ['--check-policy', '--proc', appProcLabel.text])
     }
     Process {
         id: cmd_mode
@@ -81,7 +81,7 @@ Item {
         }
         Text {
             id: appNameText
-            text: appNameLabel.text
+            text: appProcLabel.text
             color: "green"
             anchors {
                 left: appLabel.right
@@ -167,7 +167,7 @@ Item {
                 left: rulesLabel.right
             }
             onClicked: {
-                cmd_rules.start(applicationDirPath + '/utils/check_config.py', ['--copy-rules', '--proc', appNameLabel.text])
+                cmd_rules.start(applicationDirPath + '/utils/check_config.py', ['--copy-rules', '--proc', appProcLabel.text])
             }
         }
         Process {
@@ -263,7 +263,7 @@ Item {
                     permissions.push(locationCBText.text)
                 }
                 messageDialog.title = i18n.tr("Reset Permissions")
-                if (permissions.length > 0 && appNameLabel.text != 'APP NAME'){
+                if (permissions.length > 0 && appProcLabel.text != 'APP NAME'){
                     messageDialog.icon = StandardIcon.Information
                     messageDialog.text = i18n.tr("Permission restted for: ") + permissions
                     cmd_reset.start(applicationDirPath + '/utils/reset_trust_store.sh', permissions)

--- a/qml/FileWatcher.qml
+++ b/qml/FileWatcher.qml
@@ -16,7 +16,7 @@ import QtQuick.Layouts 1.2
 Item {
     Component.onCompleted: {
         console.log('Watcher loaded')
-          cmd_file_access.start(applicationDirPath + '/utils/file_watcher.py', ['--access', '--app', appNameLabel.text])
+          cmd_file_access.start(applicationDirPath + '/utils/file_watcher.py', ['--access', '--proc', appNameLabel.text])
     }
     Process {
         id: cmd_file_access

--- a/qml/FileWatcher.qml
+++ b/qml/FileWatcher.qml
@@ -16,7 +16,7 @@ import QtQuick.Layouts 1.2
 Item {
     Component.onCompleted: {
         console.log('Watcher loaded')
-          cmd_file_access.start(applicationDirPath + '/utils/file_watcher.py', ['--access', '--proc', appNameLabel.text])
+          cmd_file_access.start(applicationDirPath + '/utils/file_watcher.py', ['--access', '--proc', appProcLabel.text, '--name', appNameLabel.text])
     }
     Process {
         id: cmd_file_access

--- a/qml/LogWatcher.qml
+++ b/qml/LogWatcher.qml
@@ -14,9 +14,9 @@ import QtQuick.Layouts 1.2
 Item {
     Component.onCompleted: {
         console.log('SysLog Watcher loaded')
-          //cmd_sysLog.start(applicationDirPath + '/utils/syslog_watcher.py', ['--app', appNameLabel.text])
-          cmd_strace.start(applicationDirPath + '/utils/watcher_strace.py', ['--app', appNameLabel.text])
-          cmd_pactl.start(applicationDirPath + '/utils/watcher_pactl.py', ['--app', appNameLabel.text])
+          //cmd_sysLog.start(applicationDirPath + '/utils/syslog_watcher.py', ['--proc', appNameLabel.text])
+          cmd_strace.start(applicationDirPath + '/utils/watcher_strace.py', ['--proc', appNameLabel.text])
+          cmd_pactl.start(applicationDirPath + '/utils/watcher_pactl.py', ['--proc', appNameLabel.text])
     }
     Process {
         id: cmd_sysLog

--- a/qml/LogWatcher.qml
+++ b/qml/LogWatcher.qml
@@ -14,9 +14,9 @@ import QtQuick.Layouts 1.2
 Item {
     Component.onCompleted: {
         console.log('SysLog Watcher loaded')
-          //cmd_sysLog.start(applicationDirPath + '/utils/syslog_watcher.py', ['--proc', appNameLabel.text])
-          cmd_strace.start(applicationDirPath + '/utils/watcher_strace.py', ['--proc', appNameLabel.text])
-          cmd_pactl.start(applicationDirPath + '/utils/watcher_pactl.py', ['--proc', appNameLabel.text])
+          //cmd_sysLog.start(applicationDirPath + '/utils/syslog_watcher.py', ['--proc', appProcLabel.text])
+          cmd_strace.start(applicationDirPath + '/utils/watcher_strace.py', ['--proc', appProcLabel.text, '--name', appNameLabel.text])
+          cmd_pactl.start(applicationDirPath + '/utils/watcher_pactl.py', ['--proc', appProcLabel.text, '--name', appNameLabel.text])
     }
     Process {
         id: cmd_sysLog
@@ -76,7 +76,7 @@ Item {
 
                 function toggle(){
                     if (tcpdumpSwitch.checked){
-                        if (appNameLabel.text == "APP NAME"){
+                        if (appProcLabel.text == "APP NAME"){
                             messageDialog.icon = StandardIcon.Critical
                             messageDialog.text = i18n.tr("APP is not running")
                             messageDialog.visible = true

--- a/qml/main.qml
+++ b/qml/main.qml
@@ -47,27 +47,30 @@ Window {
             top: parent.top
             left: parent.left
         }
-        Row {
-            id: labelRow
-            anchors {
-                bottom: appRow.top
-                margins: 20
-            }
-            Text {
-                text: "Checking:"
-                font.pointSize: 10
-            }
-        }
-        Row {
-            id: appRow
+        Column {
+            id: appCol
+            spacing: units.gu(1)
             anchors {
                 bottom: adbRow.top
-                margins: 20
+                margins: units.gu(4)
+            }
+            Text {
+                text: i18n.tr("Checking:")
+                font.pointSize: 9
             }
             Text {
                 id: appNameLabel
                 text: "APP NAME"
-                font.pointSize: 10
+                font.pointSize: 9
+            }
+            Text {
+                text: i18n.tr("Process:")
+                font.pointSize: 9
+            }
+            Text {
+                id: appProcLabel
+                text: "PROC NAME"
+                font.pointSize: 9
             }
         }
         Row {
@@ -127,7 +130,6 @@ Window {
                 width: listView.width 
                 height: 80
                 color: listView.currentIndex == index ? UbuntuColors.orange : Colour.palette['Ash']
-                                   //Colour.palette['Blue'] : Colour.palette['Ash']
                 Text {
                     text: name
                     anchors.centerIn: parent
@@ -146,7 +148,6 @@ Window {
                     width: parent.height / Math.sqrt(2)
                     height: width
                     color: UbuntuColors.orange 
-                    // Colour.palette['Blue']
                     transform: Rotation { origin.x: 25; origin.y: 25; angle: 45}
                     anchors {
                         right: parent.right

--- a/utils/CodePiece/calendar_watcher.py
+++ b/utils/CodePiece/calendar_watcher.py
@@ -16,11 +16,11 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='Calendar event monitor')
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action

--- a/utils/CodePiece/calendar_watcher.py
+++ b/utils/CodePiece/calendar_watcher.py
@@ -17,10 +17,12 @@ import sys
 
 parser = argparse.ArgumentParser(description='Calendar event monitor')
 parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 try:
     proc_name = args.proc
+    app_name = args.name if args.name else 'APPNAME'
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action
@@ -42,7 +44,7 @@ try:
                     for event in events:
                         if event in output:
                             timestamp='{:%m%d %H:%M:%S}'.format(datetime.datetime.now())
-                            print("{} <APPNAME>[KEYWORD][{}]:[{}] {}".format(timestamp, proc_name, event, event))
+                            print("{} <{}>[KEYWORD][{}]:[{}] {}".format(timestamp, app_name, proc_name, event, event))
                             sys.stdout.flush()
     else:
         print(proc_name, "is not running")

--- a/utils/CodePiece/contact_watcher.py
+++ b/utils/CodePiece/contact_watcher.py
@@ -17,10 +17,12 @@ import sys
 
 parser = argparse.ArgumentParser(description='Contact activites monitor')
 parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 try:
     proc_name = args.proc
+    app_name = args.name if args.name else 'APPNAME'
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action
@@ -42,7 +44,7 @@ try:
                     for event in events:
                         if event in output:
                             timestamp='{:%m%d %H:%M:%S}'.format(datetime.datetime.now())
-                            print("{} <APPNAME>[KEYWORD][{}]:[{}] {}".format(timestamp, proc_name, event, event))
+                            print("{} <{}>[KEYWORD][{}]:[{}] {}".format(timestamp, app_name, proc_name, event, event))
                             sys.stdout.flush()
     else:
         print(proc_name, "is not running")

--- a/utils/CodePiece/contact_watcher.py
+++ b/utils/CodePiece/contact_watcher.py
@@ -16,11 +16,11 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='Contact activites monitor')
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action

--- a/utils/CodePiece/file_watcher.py
+++ b/utils/CodePiece/file_watcher.py
@@ -25,11 +25,13 @@ group.add_argument('--lsof', action='store_true',
 group.add_argument('--changes', action='store_true',
                     help='Monitor changes in {}'.format(home_dir))
 parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 if args.access:
     try:
         proc_name = args.proc
+        app_name = args.name if args.name else 'APPNAME'
         proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
         if proc_id.isnumeric():
             # Supressor list, supress 'stat', 'lstat' and 'getcwd' command

--- a/utils/CodePiece/file_watcher.py
+++ b/utils/CodePiece/file_watcher.py
@@ -24,12 +24,12 @@ group.add_argument('--lsof', action='store_true',
                     help='List opened files in {}'.format(home_dir))
 group.add_argument('--changes', action='store_true',
                     help='Monitor changes in {}'.format(home_dir))
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 if args.access:
     try:
-        proc_name = args.app
+        proc_name = args.proc
         proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
         if proc_id.isnumeric():
             # Supressor list, supress 'stat', 'lstat' and 'getcwd' command

--- a/utils/CodePiece/internet_watcher.py
+++ b/utils/CodePiece/internet_watcher.py
@@ -17,10 +17,12 @@ import sys
 
 parser = argparse.ArgumentParser(description='Network connection monitor')
 parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 try:
     proc_name = args.proc
+    app_name = args.name if args.name else 'APPNAME'
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid 127.0.0.1, 127.0.1.1 and error action
@@ -40,7 +42,7 @@ try:
                     output = re.search('sin_port\=htons\((?P<port>\d+)\).*sin_addr=inet_addr\("(?P<ip>.*)"', output)
                     if output:
                         timestamp='{:%m%d %H:%M:%S}'.format(datetime.datetime.now())
-                        print("{} <APPNAME>[KEYWORD][{}]:[connect] {}:{}".format(timestamp, proc_name, output.group("ip"),  output.group("port")))
+                        print("{} <{}>[KEYWORD][{}]:[connect] {}:{}".format(timestamp, app_name, proc_name, output.group("ip"),  output.group("port")))
                         sys.stdout.flush()
     else:
         print(proc_name, "is not running")

--- a/utils/CodePiece/internet_watcher.py
+++ b/utils/CodePiece/internet_watcher.py
@@ -16,11 +16,11 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='Network connection monitor')
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid 127.0.0.1, 127.0.1.1 and error action

--- a/utils/CodePiece/kill_proc.sh
+++ b/utils/CodePiece/kill_proc.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# Script to kill all targeted process on Ubuntu Phone.
+#
+# This file is part of the Ubuntu Phone pre-loaded app monitoring tool.
+#
+# Copyright 2016 Canonical Ltd.
+# Authors: 
+#   Po-Hsu Lin <po-hsu.lin@canonical.com>
+#
+
+target=$1
+process=`adb shell "ps aux | grep $target" | grep -v "grep" | awk '{print $2}'`
+if [ "$process" != '' ]; then
+   IFS=' ' eval "array=($process)"
+   for pid in "${array[@]}"
+   do
+       echo "killing $pid"
+       adb shell "sudo kill -9" "$pid"
+   done
+   echo "DONE"
+else
+   echo "$target is not running"
+fi

--- a/utils/CodePiece/location_watcher.py
+++ b/utils/CodePiece/location_watcher.py
@@ -16,12 +16,13 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='location event monitor')
-group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('--proc', help='Target app executable name')
+parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 try:
     proc_name = args.proc
+    app_name = args.name if args.name else 'APPNAME'
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Try to kill strace process first

--- a/utils/CodePiece/location_watcher.py
+++ b/utils/CodePiece/location_watcher.py
@@ -17,11 +17,11 @@ import sys
 
 parser = argparse.ArgumentParser(description='location event monitor')
 group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('--app', help='Targeted app')
+group.add_argument('--proc', help='Target app executable name')
 args = parser.parse_args()
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Try to kill strace process first

--- a/utils/check_config.py
+++ b/utils/check_config.py
@@ -23,7 +23,7 @@ group.add_argument('--check-policy', action='store_true',
                    help='Check the AppArmor policy for the app')
 group.add_argument('--copy-rules', action='store_true',
                    help='Copy the AppArmor Final Rules for the app')
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 
@@ -38,7 +38,7 @@ def confine_check(process_name):
 
 # Get the app name from the temperorary file
 try:
-    proc_name = args.app
+    proc_name = args.proc
     # Check if the process is running, use ubuntu-app-list with grep
     if subprocess.check_output(['adb', 'shell', 'ubuntu-app-list', '|', 'grep', proc_name]):
         if args.check_mode:

--- a/utils/list_app.py
+++ b/utils/list_app.py
@@ -32,38 +32,60 @@ if args.list:
     app_dict = {}
 
     # Get the exectuable Legacy app list (it's the title as well)
-    app_legacy = subprocess.check_output(['adb', 'shell', 'grep', '-l', 'X-Ubuntu-Touch=true', '/usr/share/applications/*.desktop']).decode('utf8')
-    app_legacy = app_legacy.replace('/usr/share/applications/', '')
-    app_legacy = app_legacy.replace('.desktop', '').split()
-    # Exclude key with "OnlyShowIn=Old" and "NoDisplay=true"
+    fn_legacy = subprocess.check_output(['adb', 'shell', 'grep', '-l', 'X-Ubuntu-Touch=true', '/usr/share/applications/*.desktop']).decode('utf8')
+    fn_legacy = fn_legacy.split()
+    # Exclude file that with "OnlyShowIn=Old" and "NoDisplay=true" key
     excludes = subprocess.check_output(['adb', 'shell', 'grep', '-l', 'OnlyShowIn=Old', '/usr/share/applications/*']).decode('utf8')
     excludes += subprocess.check_output(['adb', 'shell', 'grep', '-l', 'NoDisplay=true', '/usr/share/applications/*']).decode('utf8')
-    excludes = excludes.replace('/usr/share/applications/', '')
-    excludes = excludes.replace('.desktop', '').split()
+    excludes = excludes.split()
     for exc in excludes:
-        if exc in app_legacy:
-            app_legacy.remove(exc)
+        if exc in fn_legacy:
+            fn_legacy.remove(exc)
     # Get info for legacy apps and put them into a dictionary
-    for app in app_legacy:
-        info = subprocess.check_output(['adb', 'shell', 'dpkg', '-s', app, '|', 'grep', '-e', 'Version', '-e', 'Maintainer']).decode('utf8').rstrip()
+    for fn in fn_legacy:
+        # Reformat the executable name
+        app_exec = fn.replace('/usr/share/applications/', '')
+        app_exec = app_exec.replace('.desktop', '')
+        # Get the name in Name[zh_CN] first, if not available, use the Name instead
+        app_name = subprocess.check_output(['adb', 'shell', 'grep', '^Name\[zh_CN\]=', fn]).decode('utf8').rstrip()
+        if app_name:
+            app = app_name.split('=')[1]
+        else:
+            app_name = subprocess.check_output(['adb', 'shell', 'grep', '^Name=', fn]).decode('utf8').rstrip()
+            app = app_name.split('=')[1]
+        info = subprocess.check_output(['adb', 'shell', 'dpkg', '-s', app_exec, '|', 'grep', '-e', 'Version', '-e', 'Maintainer']).decode('utf8').rstrip()
         contact, ver = info.split('\r\n')
         contact = contact.split(': ')[1]
         ver = ver.split(': ')[1].split('+')[0]
-        app_dict[app] = {'ver': ver, 'info': contact, 'exec': app}
+        app_dict[app] = {'ver': ver, 'info': contact, 'exec': app_exec}
 
     # Get the complete info of Click app from manifest
     data = subprocess.check_output(['adb', 'shell', 'click', 'list', '--manifest']).decode('utf8')
     data = json.loads(data)
     # Get the exectuable Click app list
-    app_click = subprocess.check_output(['adb', 'shell', 'grep', '-l', 'X-Ubuntu-Touch=true', '/home/phablet/.local/share/applications/*.desktop']).decode('utf8')
-    app_click = app_click.replace('/home/phablet/.local/share/applications/', '')
-    app_click = app_click.replace('.desktop', '').split()
+    fn_click = subprocess.check_output(['adb', 'shell', 'grep', '-l', 'X-Ubuntu-Touch=true', '/home/phablet/.local/share/applications/*.desktop']).decode('utf8')
+    fn_click = fn_click.split()
+
+    # Put app name into a dictionary for later query
+    app_click = {}
+    for fn in fn_click:
+        # Reformat the executable name
+        app_exec = fn.replace('/home/phablet/.local/share/applications/', '')
+        app_exec = app_exec.replace('.desktop', '')
+        # Get the name in Name[zh_CN] first, if not available, use the Name instead
+        app_name = subprocess.check_output(['adb', 'shell', 'grep', '^Name\[zh_CN\]=', fn]).decode('utf8').rstrip()
+        if app_name:
+            app = app_name.split('=')[1]
+        else:
+            app_name = subprocess.check_output(['adb', 'shell', 'grep', '^Name=', fn]).decode('utf8').rstrip()
+            app = app_name.split('=')[1]
+        app_click[app_exec] = app
     # Reorganize information and combine with current dictionary
     for item in data:
         if any(item['name'] in app for app in app_click):
             for i, executable in enumerate(app_click):
                 if item['name'] in executable:
-                    app_dict[item['title']] = {'ver': item['version'], 'info': item['maintainer'], 'exec': executable}
+                    app_dict[app_click[executable]] = {'ver': item['version'], 'info': item['maintainer'], 'exec': executable}
                     break
     # Return app titles and version here for QML combobox
     for app in app_dict:

--- a/utils/list_app.py
+++ b/utils/list_app.py
@@ -87,9 +87,10 @@ if args.list:
                 if item['name'] in executable:
                     app_dict[app_click[executable]] = {'ver': item['version'], 'info': item['maintainer'], 'exec': executable}
                     break
+
     # Return app titles and version here for QML combobox
     for app in app_dict:
-        print('{} ({}), {}, {}'.format(app, app_dict[app]['ver'], app_dict[app]['exec'], app_dict[app]['info']))
+        print('{}, ({}), {}, {}'.format(app, app_dict[app]['ver'], app_dict[app]['exec'], app_dict[app]['info']))
 
 if args.watch:
     try:

--- a/utils/mm_watcher.py
+++ b/utils/mm_watcher.py
@@ -17,10 +17,12 @@ import sys
 
 parser = argparse.ArgumentParser(description='Mobile network switch monitor')
 parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 try:
     proc_name = args.proc
+    app_name = args.name if args.name else 'APPNAME'
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action
@@ -43,7 +45,7 @@ try:
                         if event in output:
                             timestamp='{:%m%d %H:%M:%S}'.format(datetime.datetime.now())
                             action = re.search('(\w+)', event).group(0)
-                            print("{} <APPNAME>[KEYWORD][{}]:[{}] {}: {}".format(timestamp, proc_name, action, action, events[event]))
+                            print("{} <{}>[KEYWORD][{}]:[{}] {}: {}".format(timestamp, app_name, proc_name, action, action, events[event]))
                             sys.stdout.flush()
                             break
     else:

--- a/utils/mm_watcher.py
+++ b/utils/mm_watcher.py
@@ -16,11 +16,11 @@ import subprocess
 import sys
 
 parser = argparse.ArgumentParser(description='Mobile network switch monitor')
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action

--- a/utils/syslog_watcher.py
+++ b/utils/syslog_watcher.py
@@ -20,14 +20,14 @@ parser = argparse.ArgumentParser(description='Syslog monitor')
 group = parser.add_mutually_exclusive_group(required=True)
 group.add_argument('--denied', action='store_true',
                    help='Monitor DENIED pattern in syslog')
-group.add_argument('--app', help='Targeted app')
+group.add_argument('--proc', help='Target app executable name')
 args = parser.parse_args()
 
 try:
     if args.denied:
         proc_name = 'DENIED'
     else:
-        proc_name = args.app
+        proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric() or args.denied:
         # Try to kill tailf process first

--- a/utils/watcher_pactl.py
+++ b/utils/watcher_pactl.py
@@ -21,12 +21,12 @@ import kill_proc
 
 parser = argparse.ArgumentParser(description='Sensitive event monitor with pactl')
 group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('--app', help='Target app')
+group.add_argument('--proc', help='Target app executable name')
 args = parser.parse_args()
 
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     # It's no necessary to get PID here, but still check it
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():

--- a/utils/watcher_pactl.py
+++ b/utils/watcher_pactl.py
@@ -20,13 +20,14 @@ import sys
 import kill_proc
 
 parser = argparse.ArgumentParser(description='Sensitive event monitor with pactl')
-group = parser.add_mutually_exclusive_group(required=True)
-group.add_argument('--proc', help='Target app executable name')
+parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--name', help='Target app human readable name')
 args = parser.parse_args()
 
 
 try:
     proc_name = args.proc
+    app_name = args.name if args.name else 'APPNAME'
     # It's no necessary to get PID here, but still check it
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
@@ -51,7 +52,7 @@ try:
                             timestamp='{:%m%d %H:%M:%S}'.format(datetime.datetime.now())
                             print("{TIME} <{APP}>[{KEYWORD}][{PROC}]:[{FUNC}] {ACT} {PARM}".format(
                                 TIME = timestamp,
-                                APP = "APPNAME",
+                                APP = app_name,
                                 KEYWORD = "KEYWORD",
                                 PROC = proc_name,
                                 FUNC = 'source',

--- a/utils/watcher_strace.py
+++ b/utils/watcher_strace.py
@@ -38,11 +38,11 @@ def printer(proc_name, func_name, act_name, item):
 
 
 parser = argparse.ArgumentParser(description='Sensitive event monitor with strace')
-parser.add_argument('--app', help='Target app', required=True)
+parser.add_argument('--proc', help='Target app executable name', required=True)
 args = parser.parse_args()
 
 try:
-    proc_name = args.app
+    proc_name = args.proc
     proc_id = subprocess.check_output(['adb', 'shell', 'ubuntu-app-pid', proc_name]).decode('utf-8').rstrip()
     if proc_id.isnumeric():
         # Supressor list, get rid of error action, and local ip for connect event


### PR DESCRIPTION
Use the zh_CN key in the desktop file to get the translated app name, change the old --name argument to --proc and use it to assign process name. Add a new --name argument to assign translated, human readable app name for log output.

This new feature will slow down the list_app script, it will take about 12 seconds now, as addressed in #52,
we will need to reduce the use of adb shell command to speed it up.

This fixes #94 
