### PR TITLE
Add call history event monitor

### DIFF
--- a/utils/watcher_strace.py
+++ b/utils/watcher_strace.py
@@ -40,7 +40,8 @@ try:
         events = {'AddressBook': ('updateContacts', 'removeContacts', 'createContact', 'contactsDetails'),
                   'Calendar': ('CreateObjects', 'RemoveObjects', 'ModifyObjects', 'GetObjectList'),
                   'location': ('StartPositionUpdates', 'StopPositionUpdates'),
-                  'connectivity': ('MobileDataEnabled', 'DataRoamingEnabled')}
+                  'connectivity': ('MobileDataEnabled', 'DataRoamingEnabled'),
+                  'HistoryService': ('QueryEvents', 'RemoveEvents')}
         # Target directories, assume user name will be phablet
         home = '/home/phablet/'
         dirs = ('Documents', 'Music', 'Pictures', 'Videos')


### PR DESCRIPTION
Add call history event monitor.
Able to monitor add(contactsDetails in AddressBook), remove(RemoveEvents), and get details(QueryEvents).
