### PR TITLE
Add FileDialog for file copy

### DIFF
--- a/qml/CheckConfig.qml
+++ b/qml/CheckConfig.qml
@@ -170,7 +170,13 @@ Item {
                 left: rulesLabel.right
             }
             onClicked: {
-                cmd_rules.start(applicationDirPath + '/utils/check_config.py', ['--copy-rules', '--proc', appProcLabel.text])
+                if (appProcLabel.text == "PROC NAME") {
+                    messageDialog.icon = StandardIcon.Critical
+                    messageDialog.text = i18n.tr("Error: App is not running")
+                    messageDialog.visible = true
+                } else {
+                    fileDialog.visible = true
+                }
             }
         }
         Process {
@@ -182,10 +188,6 @@ Item {
                     messageDialog.icon = StandardIcon.Critical
                     messageDialog.text = i18n.tr("Failed to copy file")
                     console.log(messageDialog.text)
-                } else {
-                    messageDialog.icon = StandardIcon.Information
-                    messageDialog.text = i18n.tr("File copied to: ") + applicationDirPath + '/'
-                    console.log(messageDialog.text)
                 }
                 messageDialog.visible = true
             }
@@ -194,6 +196,28 @@ Item {
         MessageDialog {
             id: messageDialog
         }
+        FileDialog {
+            id: fileDialog
+            title: i18n.tr("Please choose a directory for the log")
+            folder: shortcuts.documents
+            selectMultiple: false
+            selectFolder: true
+            onAccepted: {
+                var local_dir = fileDialog.folder.toString().replace(/file:\/\//, "")
+                cmd_rules.start(applicationDirPath + '/utils/check_config.py', ['--copy-rules', '--proc', appProcLabel.text, '--path', local_dir])
+                messageDialog.icon = StandardIcon.Information
+                messageDialog.title = i18n.tr("File copy")
+                messageDialog.text = i18n.tr("File copied to: ") + local_dir
+                messageDialog.visible = true
+            }
+            onRejected: {
+                messageDialog.title = i18n.tr("File copy")
+                messageDialog.icon = StandardIcon.Warning
+                messageDialog.text = i18n.tr("Operation cancelled")
+                messageDialog.visible = true
+            }
+    }
+
     }
     RowLayout {
         anchors {

--- a/qml/LogWatcher.qml
+++ b/qml/LogWatcher.qml
@@ -76,7 +76,7 @@ Item {
 
                 function toggle(){
                     if (tcpdumpSwitch.checked){
-                        if (appProcLabel.text == "APP NAME"){
+                        if (appProcLabel.text == "PROC NAME"){
                             messageDialog.icon = StandardIcon.Critical
                             messageDialog.text = i18n.tr("APP is not running")
                             messageDialog.visible = true
@@ -117,15 +117,33 @@ Item {
                     if (tcpfnText.text == ""){
                         messageDialog.icon = StandardIcon.Critical
                         messageDialog.text = i18n.tr("Please start TCP dump first")
+                        messageDialog.visible = true
                     } else {
-                        messageDialog.title = i18n.tr("File copy")
-                        messageDialog.icon = StandardIcon.Information
-                        messageDialog.text = i18n.tr("File copied to: ") + applicationDirPath + '/'
-                        cmd_tcpPull.start(applicationDirPath + '/utils/adb', ['pull', tcpfnText.text])
+                        fileDialog.visible = true
                     }
-                    messageDialog.visible = true;
                 }
             } 
+            FileDialog {
+                id: fileDialog
+                title: i18n.tr("Please choose a directory for the log")
+                folder: shortcuts.documents
+                selectMultiple: false
+                selectFolder: true
+                onAccepted: {
+                    var local_path = fileDialog.folder.toString().replace(/file:\/\//, "")
+                    cmd_tcpPull.start(applicationDirPath + '/utils/adb', ['pull', tcpfnText.text, local_path])
+                    messageDialog.title = i18n.tr("File copy")
+                    messageDialog.icon = StandardIcon.Information
+                    messageDialog.text = i18n.tr("File copied to: ") + local_path
+                    messageDialog.visible = true
+                }
+                onRejected: {
+                    messageDialog.title = i18n.tr("File copy")
+                    messageDialog.icon = StandardIcon.Warning
+                    messageDialog.text = i18n.tr("Operation cancelled")
+                    messageDialog.visible = true
+                }
+            }
             Text {
                 id: tcpfnText
                 text: ""

--- a/utils/check_config.py
+++ b/utils/check_config.py
@@ -11,6 +11,7 @@ Authors:
 
 import argparse
 import json
+import os
 import subprocess
 
 parser = argparse.ArgumentParser(description='Check basic config for an App')
@@ -24,6 +25,7 @@ group.add_argument('--check-policy', action='store_true',
 group.add_argument('--copy-rules', action='store_true',
                    help='Copy the AppArmor Final Rules for the app')
 parser.add_argument('--proc', help='Target app executable name', required=True)
+parser.add_argument('--path', help='Target directory for saving the log')
 args = parser.parse_args()
 
 
@@ -57,17 +59,17 @@ try:
                 print("No")
         elif args.check_policy:
             if confine_check(proc_name):
-                path = '/var/lib/apparmor/clicks/{}.json'.format(proc_name)
-                output = subprocess.check_output(['adb', 'shell', 'cat', path]).decode('utf8')
+                remote_path = '/var/lib/apparmor/clicks/{}.json'.format(proc_name)
+                output = subprocess.check_output(['adb', 'shell', 'cat', remote_path]).decode('utf8')
                 output = json.loads(output)
                 for key in output:
                     print(key, ':',output[key])
             else:
                 print("Unconfined App, no policy file available")
         elif args.copy_rules:
-            path = '/var/lib/apparmor/profiles/click_{}'.format(proc_name)
-            output = subprocess.check_output(['adb', 'pull', path]).decode('utf8')
-            import pdb; pdb.set_trace()
+            local_path = args.path if args.path else os.getcwd()
+            remote_path = '/var/lib/apparmor/profiles/click_{}'.format(proc_name)
+            output = subprocess.check_output(['adb', 'pull', remote_path, local_path]).decode('utf8')
             print("Done: file copied")
     else:
         print("Error: App is not running")


### PR DESCRIPTION
Add FileDialog for file copy, it's defaulted to ~/Documents, user can select where to store the file now.
It's combined with normal message dialogue, we can modularized it in the future.

This closes #102 
