### PR TITLE
Print sorted app list

### DIFF
--- a/utils/list_app.py
+++ b/utils/list_app.py
@@ -112,7 +112,7 @@ try:
                         break
 
         # Return app titles and version here for QML combobox
-        for app in app_dict:
+        for app in sorted(app_dict):
             print('{}, {}, ({}), {}, {}'.format(
                 app,
                 app_dict[app]['keyword'],


### PR DESCRIPTION
Print the sorted app list, so it will be consistent every time.

This closes #31 
