### PR TITLE
Fix the pactl watcher noisy issue

### DIFF
--- a/utils/watcher_pactl.py
+++ b/utils/watcher_pactl.py
@@ -37,7 +37,7 @@ try:
         # Kill the old pactl subscribe task first
         common_tools.kill('pactl')
         # Track the audio recording event with pactl
-        cmd = ['adb', 'shell', 'pactl', 'subscribe', '|', 'grep', 'source #']
+        cmd = ['adb', 'shell', 'pactl', 'subscribe', '|', 'grep', 'source-output #']
         process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         while True:
             output = process.stdout.readline().decode('utf-8').strip()


### PR DESCRIPTION
Improve the pactl filter, to make it not to print irrelevant events.

This fixes #128 
